### PR TITLE
Fix wrong confirmation

### DIFF
--- a/Chapter 6 - Connecting Sites and Bots/Chapter 6.3 - Beginning the Connection/project10/app.js
+++ b/Chapter 6 - Connecting Sites and Bots/Chapter 6.3 - Beginning the Connection/project10/app.js
@@ -163,7 +163,7 @@ app.get('/deposit', (req, res) => {
         steamid: req.user.steamid
       },
       (err, inv) => {
-        if (inv && Date.now() - inv.updated > 6 * 60 * 60 * 1000) {
+        if (inv && Date.now() - inv.updated < 6 * 60 * 60 * 1000) {
           res.render('deposit', {
             user: req.user,
             items: inv.items


### PR DESCRIPTION
It was refreshing the prices for inventories refreshed less than 6 hours ago, instead of the opposite