### PR TITLE
Update Chapter2.2 README with Steam Premium info

### DIFF
--- a/Chapter 2 - Trading/Chapter 2.2 - Handling Trade Offers/README.md
+++ b/Chapter 2 - Trading/Chapter 2.2 - Handling Trade Offers/README.md
@@ -92,9 +92,8 @@ To test this out, run the program using `node project2.js` and use the trusted
 account to send an offer to the bot. If you don't have a second account, use a
 friend's Steam ID as the trusted account, and have them send your bot an offer.
 
-**Note that your Bot needs to have at least a $5 purchase on Steam to be eligible
-to recieve trading offers, else the ```newOffer``` event will simply not fire.**
-
+> **Note that your bot needs to have at least a $5 purchase on Steam to be eligible
+> to receive trade offers. Otherwise, the ```newOffer``` event will not fire.**
 
 Sure enough, when the trade gets sent, something like this should appear in
 your console:

--- a/Chapter 2 - Trading/Chapter 2.2 - Handling Trade Offers/README.md
+++ b/Chapter 2 - Trading/Chapter 2.2 - Handling Trade Offers/README.md
@@ -92,6 +92,10 @@ To test this out, run the program using `node project2.js` and use the trusted
 account to send an offer to the bot. If you don't have a second account, use a
 friend's Steam ID as the trusted account, and have them send your bot an offer.
 
+**Note that your Bot needs to have at least a $5 purchase on Steam to be eligible
+to recieve trading offers, else the ```newOffer``` event will simply not fire.**
+
+
 Sure enough, when the trade gets sent, something like this should appear in
 your console:
 


### PR DESCRIPTION
Updates the Chapter 2.2 explaining that the newOffer event will not fire if your bot has not paid at least $5.