### PR TITLE
Updates Chapter 1.5, adding cause of InvalidPassword error

### DIFF
--- a/Chapter 1 - Basics/Chapter 1.5 - Errors/README.md
+++ b/Chapter 1 - Basics/Chapter 1.5 - Errors/README.md
@@ -18,4 +18,5 @@ incorrectly. Try reinstalling it by typing `npm install THE_MODULE_NAME` again.
 
 This means you have likely specified an incorrect `accountName` or `password`.
 Try re-entering them and make sure they work when logging into the Steam
-client.
+client. 
+This error can also be caused by passing the `twoFactorCode` in the logOnOptions object, while your bot does not currently have Two Factor Authentication (2FA) enabled.


### PR DESCRIPTION
Tells the user that the InvalidPassword error can occur if they put the twoFactorCode parameter in the logonOptions object, while the bot is not using 2FA.