### PR TITLE
Fix outdated usage of EPersonaState from `steam-user`

### DIFF
--- a/Chapter 1 - Basics/Chapter 1.3 - Starting to Code/README.md
+++ b/Chapter 1 - Basics/Chapter 1.3 - Starting to Code/README.md
@@ -108,7 +108,7 @@ its status to online and start playing some good ol' Team Fortress 2.
 client.on('loggedOn', () => {
   console.log('Logged into Steam');
 
-  client.setPersona(SteamUser.Steam.EPersonaState.Online);
+  client.setPersona(SteamUser.EPersonaState.Online);
   client.gamesPlayed(440);
 });
 ```
@@ -124,7 +124,7 @@ and the second being a persona name. The persona name is not required, but can
 be set if you would like to change your Steam name. For example, we could use:
 
 ```js
-client.setPersona(SteamUser.Steam.EPersonaState.Online, 'andrewda');
+client.setPersona(SteamUser.EPersonaState.Online, 'andrewda');
 ```
 
 to change our Steam name to "andrewda". The `gamesPlayed` method takes one

--- a/Chapter 1 - Basics/Chapter 1.3 - Starting to Code/project1.js
+++ b/Chapter 1 - Basics/Chapter 1.3 - Starting to Code/project1.js
@@ -12,6 +12,6 @@ client.logOn(logOnOptions);
 client.on('loggedOn', () => {
   console.log('Logged into Steam!');
 
-  client.setPersona(SteamUser.Steam.EPersonaState.Online);
+  client.setPersona(SteamUser.EPersonaState.Online);
   client.gamesPlayed(440);
 });

--- a/Chapter 1 - Basics/Chapter 1.4 - TOTP/README.md
+++ b/Chapter 1 - Basics/Chapter 1.4 - TOTP/README.md
@@ -24,7 +24,7 @@ client.logOn(logOnOptions);
 client.on('loggedOn', () => {
   console.log('Logged into Steam');
 
-  client.setPersona(SteamUser.Steam.EPersonaState.Online);
+  client.setPersona(SteamUser.EPersonaState.Online);
   client.gamesPlayed(440);
 });
 ```

--- a/Chapter 1 - Basics/Chapter 1.4 - TOTP/project1.js
+++ b/Chapter 1 - Basics/Chapter 1.4 - TOTP/project1.js
@@ -15,6 +15,6 @@ client.logOn(logOnOptions);
 client.on('loggedOn', () => {
   console.log('Logged into Steam');
 
-  client.setPersona(SteamUser.Steam.EPersonaState.Online);
+  client.setPersona(SteamUser.EPersonaState.Online);
   client.gamesPlayed(440);
 });

--- a/Chapter 2 - Trading/Chapter 2.2 - Handling Trade Offers/project2.js
+++ b/Chapter 2 - Trading/Chapter 2.2 - Handling Trade Offers/project2.js
@@ -23,7 +23,7 @@ client.logOn(logOnOptions);
 client.on('loggedOn', () => {
   console.log('Logged into Steam');
 
-  client.setPersona(SteamUser.Steam.EPersonaState.Online);
+  client.setPersona(SteamUser.EPersonaState.Online);
   client.gamesPlayed(440);
 });
 

--- a/Chapter 2 - Trading/Chapter 2.3 - Sending Trade Offers/project2.js
+++ b/Chapter 2 - Trading/Chapter 2.3 - Sending Trade Offers/project2.js
@@ -23,7 +23,7 @@ client.logOn(logOnOptions);
 client.on('loggedOn', () => {
   console.log('Logged into Steam');
 
-  client.setPersona(SteamUser.Steam.EPersonaState.Online);
+  client.setPersona(SteamUser.EPersonaState.Online);
   client.gamesPlayed(440);
 });
 

--- a/Chapter 2 - Trading/Chapter 2.4 - Accepting Donations/project3.js
+++ b/Chapter 2 - Trading/Chapter 2.4 - Accepting Donations/project3.js
@@ -23,7 +23,7 @@ client.logOn(logOnOptions);
 client.on('loggedOn', () => {
   console.log('Logged into Steam');
 
-  client.setPersona(SteamUser.Steam.EPersonaState.Online);
+  client.setPersona(SteamUser.EPersonaState.Online);
   client.gamesPlayed(440);
 });
 

--- a/Chapter 3 - User Interaction/Chapter 3.1 - Friend Requests/project4.js
+++ b/Chapter 3 - User Interaction/Chapter 3.1 - Friend Requests/project4.js
@@ -15,7 +15,7 @@ client.logOn(logOnOptions);
 client.on('loggedOn', () => {
   console.log('Logged into Steam');
 
-  client.setPersona(SteamUser.Steam.EPersonaState.Online);
+  client.setPersona(SteamUser.EPersonaState.Online);
   client.gamesPlayed(440);
 });
 

--- a/Chapter 6 - Connecting Sites and Bots/Chapter 6.3 - Beginning the Connection/README.md
+++ b/Chapter 6 - Connecting Sites and Bots/Chapter 6.3 - Beginning the Connection/README.md
@@ -74,7 +74,7 @@ class SteamBot {
 		this.client.on('loggedOn', () => {
 			console.log('Logged into Steam');
 
-			this.client.setPersona(SteamUser.Steam.EPersonaState.Online);
+			this.client.setPersona(SteamUser.EPersonaState.Online);
 			this.client.gamesPlayed(730);
 		});
 

--- a/Chapter 6 - Connecting Sites and Bots/Chapter 6.3 - Beginning the Connection/project10/bots/index.js
+++ b/Chapter 6 - Connecting Sites and Bots/Chapter 6.3 - Beginning the Connection/project10/bots/index.js
@@ -22,7 +22,7 @@ class SteamBot {
     this.client.on('loggedOn', () => {
       console.log('Logged into Steam');
 
-      this.client.setPersona(SteamUser.Steam.EPersonaState.Online);
+      this.client.setPersona(SteamUser.EPersonaState.Online);
       this.client.gamesPlayed(730);
     });
 


### PR DESCRIPTION
Following the guide currently results in a `TypeError: Cannot read property 'EPersonaState' of undefined` because `steam-user` does not export the `EPersonaState` via `SteamUser.Steam.EPersonaState` anymore but directly via `SteamUser.EPersonaState`.

You can see [here](https://github.com/DoctorMcKay/node-steam-user/blob/master/resources/enums.js#L65) and [here](https://github.com/DoctorMcKay/node-steam-user/blob/master/index.js#L18) where they export it now.

There is also an issue (#94) about this.